### PR TITLE
Use SSL by default

### DIFF
--- a/lib/vmc/const.rb
+++ b/lib/vmc/const.rb
@@ -5,7 +5,7 @@ module VMC
   VERSION = '0.3.2'
 
   # Targets
-  DEFAULT_TARGET = 'http://api.cloudfoundry.com'
+  DEFAULT_TARGET = 'https://api.cloudfoundry.com'
   DEFAULT_LOCAL_TARGET = 'http://api.vcap.me'
 
   # General Paths

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -20,9 +20,14 @@ describe 'VMC::Client' do
     client.target.should == VMC::DEFAULT_TARGET
   end
 
+  it 'should default to use secure protocol' do
+    client = VMC::Client.new
+    client.target.match(/^https/)
+  end
+
   it 'should normalize target with no scheme' do
     client = VMC::Client.new('api.cloudfoundry.com')
-    client.target.should == @target
+    client.target.should == 'http://api.cloudfoundry.com'
   end
 
   it 'should properly initialize with auth_token' do


### PR DESCRIPTION
'vmc login' sends password to the API server so I want to be sure to use SSL by default.
