### PR TITLE
Spec cleanup about https_proxy

### DIFF
--- a/lib/vmc/client.rb
+++ b/lib/vmc/client.rb
@@ -374,7 +374,11 @@ class VMC::Client
   end
 
   def perform_http_request(req)
-    RestClient.proxy = ENV['https_proxy'] || ENV['http_proxy']
+    if URI::HTTPS === URI.parse(req[:url])
+      RestClient.proxy = ENV['https_proxy'] || ENV['http_proxy']
+    else
+      RestClient.proxy = ENV['http_proxy']
+    end
 
     # Setup tracing if needed
     unless trace.nil?

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -275,7 +275,7 @@ describe 'VMC::Client' do
     info_path = "#{@local_target}#{VMC::INFO_PATH}"
     stub_request(:get, info_path).to_return(File.new(spec_asset('info_return.txt')))
     proxy = 'http://proxy.vmware.com:3128'
-    secure_proxy = 'http://proxy.vmware.com:3128'
+    secure_proxy = 'http://secure-proxy.vmware.com:3128'
     ENV['http_proxy'] = proxy
     ENV['https_proxy'] = secure_proxy
     client = VMC::Client.new(@local_target)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -271,7 +271,20 @@ describe 'VMC::Client' do
     ENV['http_proxy'] = nil
   end
 
-  it 'should set a secure proxy over a normal proxy if one is set' do
+  it 'should use a secure proxy over a normal proxy if one is set' do
+    info_path = "#{@target}#{VMC::INFO_PATH}"
+    stub_request(:get, info_path).to_return(File.new(spec_asset('info_return.txt')))
+    proxy = 'http://proxy.vmware.com:3128'
+    secure_proxy = 'http://secure-proxy.vmware.com:3128'
+    ENV['http_proxy'] = proxy
+    ENV['https_proxy'] = secure_proxy
+    client = VMC::Client.new(@target)
+    info = client.info
+    RestClient.proxy.should == secure_proxy
+    ENV['http_proxy'] = ENV['https_proxy'] = nil
+  end
+
+  it 'should not use a secure proxy for non-secure site' do
     info_path = "#{@local_target}#{VMC::INFO_PATH}"
     stub_request(:get, info_path).to_return(File.new(spec_asset('info_return.txt')))
     proxy = 'http://proxy.vmware.com:3128'
@@ -280,7 +293,7 @@ describe 'VMC::Client' do
     ENV['https_proxy'] = secure_proxy
     client = VMC::Client.new(@local_target)
     info = client.info
-    RestClient.proxy.should == secure_proxy
+    RestClient.proxy.should == proxy
     ENV['http_proxy'] = ENV['https_proxy'] = nil
   end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -275,7 +275,7 @@ describe 'VMC::Client' do
     info_path = "#{@local_target}#{VMC::INFO_PATH}"
     stub_request(:get, info_path).to_return(File.new(spec_asset('info_return.txt')))
     proxy = 'http://proxy.vmware.com:3128'
-    secure_proxy = 'https://proxy.vmware.com:3128'
+    secure_proxy = 'http://proxy.vmware.com:3128'
     ENV['http_proxy'] = proxy
     ENV['https_proxy'] = secure_proxy
     client = VMC::Client.new(@local_target)


### PR DESCRIPTION
There's no 'secure proxy' which has 'https' as a scheme. https_proxy is
for 'HTTP proxy for HTTPS connection'. RestClient silently ignores the
scheme difference (just use host and port.)
