### PR TITLE
Displaying the runtime option to the push help messages

### DIFF
--- a/lib/cli/runner.rb
+++ b/lib/cli/runner.rb
@@ -286,7 +286,7 @@ class VMC::Cli::Runner
       set_cmd(:apps, :crashlogs, 1)
 
     when 'push'
-      usage('vmc push [appname] [--path PATH] [--url URL] [--instances N] [--mem] [--no-start]')
+      usage('vmc push [appname] [--path PATH] [--url URL] [--instances N] [--mem] [--runtime RUNTIME] [--no-start]')
       if @args.size == 1
         set_cmd(:apps, :push, 1)
       else

--- a/lib/cli/usage.rb
+++ b/lib/cli/usage.rb
@@ -38,6 +38,7 @@ Currently available vmc commands are:
     push [appname] --url                         Set the url for the application
     push [appname] --instances <N>               Set the expected number <N> of instances
     push [appname] --mem M                       Set the memory reservation for the application
+    push [appname] --runtime RUNTIME             Set the runtime to use for the application
     push [appname] --no-start                    Do not auto-start the application
 
   Application Operations


### PR DESCRIPTION
Both the "vmc help" and "vmc help push" commands now display how to choose
which runtime the new application should use when it's created.
