### PR TITLE
Ssh tunnel support

### DIFF
--- a/lib/cli/commands/base.rb
+++ b/lib/cli/commands/base.rb
@@ -29,7 +29,7 @@ module VMC::Cli
 
       def client
         return @client if @client
-        @client = VMC::Client.new(target_url, auth_token)
+        @client = VMC::Client.new(target_url, auth_token, @options)
         @client.trace = VMC::Cli::Config.trace if VMC::Cli::Config.trace
         @client.proxy_for @options[:proxy] if @options[:proxy]
         @client

--- a/lib/cli/commands/misc.rb
+++ b/lib/cli/commands/misc.rb
@@ -5,6 +5,18 @@ module VMC::Cli::Command
       say "vmc #{VMC::Cli::VERSION}"
     end
 
+    def tunnel(target)
+      
+      # @options[:tunnel_host]
+      say("tunnel to #{target} open for http://*.vcap.me:#{client.port}".green)
+      say("Control-C to exit...")
+      while true
+        sleep 5
+      end
+    rescue Interrupt => e
+      puts "\nclosing tunnel..."
+    end
+
     def target
       return display JSON.pretty_generate({:target => target_url}) if @options[:json]
       banner "[#{target_url}]"
@@ -27,7 +39,7 @@ module VMC::Cli::Command
     def set_target(target_url)
       target_url = "http://#{target_url}" unless /^https?/ =~ target_url
       target_url = target_url.gsub(/\/+$/, '')
-      client = VMC::Client.new(target_url)
+      client = VMC::Client.new(target_url, nil, @options)
       unless client.target_valid?
         if prompt_ok
           display "Host is not valid: '#{target_url}'".red

--- a/lib/cli/runner.rb
+++ b/lib/cli/runner.rb
@@ -1,5 +1,6 @@
 
 require 'optparse'
+require 'highline/import'
 
 require File.dirname(__FILE__) + '/usage'
 
@@ -50,6 +51,16 @@ class VMC::Cli::Runner
 
       opts.on('-q', '--quiet')     {         @options[:quiet] = true }
 
+      # tunnel options
+      opts.on('--tunnel-host HOST') { |thost| @options[:tunnel_host] = thost }
+      opts.on('--tunnel-user USER') { |tuser| @options[:tunnel_user] = tuser }
+      opts.on('--tunnel-port [PORT]') do |tport|
+        @options[:tunnel_port] = tport.nil? ? nil : tport
+      end
+      opts.on('--tunnel-password [PASSWORD]') do |tpass|
+        @options[:tunnel_password] = tpass.nil? ? true : tpass
+      end
+
       # Don't use builtin zip
       opts.on('--no-zip')          {         @options[:nozip] = true }
       opts.on('--nozip')           {         @options[:nozip] = true }
@@ -89,7 +100,15 @@ class VMC::Cli::Runner
     @args = opts_parser.parse!(@args)
     @args.concat instances_delta_arg
     convert_options!
+
+    set_option_default(:tunnel_port, 80)
+    set_option_default(:tunnel_user, "vcap")
+
     self
+  end
+
+  def set_option_default(name, value)
+    @options[name] = value unless @options.has_key?(name)
   end
 
   def check_instances_delta!
@@ -348,6 +367,12 @@ class VMC::Cli::Runner
       usage('vmc clone-services <src-app> <dest-app>')
       set_cmd(:services, :clone_services, 2)
 
+    when 'tunnel'
+      usage('vmc tunnel <target>')
+      set_cmd(:misc, :tunnel, 1)
+      # nasty hack to set argument as an option
+      @options[:tunnel_host] = @args[0]
+
     when 'aliases'
       usage('vmc aliases')
       set_cmd(:misc, :aliases)
@@ -424,6 +449,11 @@ class VMC::Cli::Runner
 
     process_aliases!
     parse_command!
+
+    # only ask for password if --tunnel-password was used without an argument
+    if @options[:tunnel_host] && @options[:tunnel_password].nil?
+      @options[:tunnel_password] = ask("Tunnel password: ") { |q| q.echo = "*" }
+    end
 
     if @namespace && @action
       eval("VMC::Cli::Command::#{@namespace.to_s.capitalize}").new(@options).send(@action.to_sym, *@args)

--- a/lib/cli/runner.rb
+++ b/lib/cli/runner.rb
@@ -104,9 +104,14 @@ class VMC::Cli::Runner
     exit
   end
 
+  def option_to_integer(name)
+    @options[name] = Integer(@options[name]) if @options[name]
+  end
+
   def convert_options!
     # make sure certain options are valid and in correct form.
-    @options[:instances] = Integer(@options[:instances]) if @options[:instances]
+    option_to_integer(:instances)
+    option_to_integer(:instance)
   end
 
   def set_cmd(namespace, action, args_range=0)

--- a/lib/cli/runner.rb
+++ b/lib/cli/runner.rb
@@ -406,8 +406,7 @@ class VMC::Cli::Runner
 
   def run
 
-    trap('TERM') { print "\nInterrupted\n"; exit(false)}
-    trap('INT')  { print "\nInterrupted\n"; exit(false)}
+    trap('TERM') { print "\nTerminated\n"; exit(false)}
 
     parse_options!
 
@@ -462,6 +461,9 @@ class VMC::Cli::Runner
   rescue SyntaxError => e
     puts e.message.red
     puts e.backtrace
+    @exit_status = false
+  rescue Interrupt => e
+    say("\nInterrupted".red)
     @exit_status = false
   rescue => e
     puts e.message.red

--- a/spec/unit/cli_opts_spec.rb
+++ b/spec/unit/cli_opts_spec.rb
@@ -5,8 +5,6 @@ describe 'VMC::Cli::Runner' do
   it 'should parse email and password correctly' do
     args = "--email derek@gmail.com --password foo"
     cli = VMC::Cli::Runner.new(args.split).parse_options!
-    cli.options.should have(3).items
-    cli.options.should have_key :email
     cli.options[:email].should == 'derek@gmail.com'
     cli.options[:password].should == 'foo'
   end
@@ -70,4 +68,19 @@ describe 'VMC::Cli::Runner' do
     cli.options[:all].should be_true
   end
 
+  it "should parse tunnel options correctly" do
+    args = "--tunnel-host 1.2.3.4 --tunnel-user user --tunnel-password pass --tunnel-port 1234"
+    cli = VMC::Cli::Runner.new(args.split).parse_options!
+    cli.options[:tunnel_host].should == "1.2.3.4"
+    cli.options[:tunnel_user].should == "user"
+    cli.options[:tunnel_password].should == "pass"
+    cli.options[:tunnel_port].should == "1234"
+  end
+
+  it "should get default tunnel options correctly" do
+    args = ""
+    cli = VMC::Cli::Runner.new(args.split).parse_options!
+    cli.options[:tunnel_user].should == "vcap"
+    cli.options[:tunnel_port].should == 80
+  end
 end

--- a/vmc.gemspec
+++ b/vmc.gemspec
@@ -21,6 +21,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency "highline", "~> 1.6.1"
   s.add_dependency "rest-client", ">= 1.6.1", "< 1.7.0"
   s.add_dependency "terminal-table", "~> 1.4.2"
+  s.add_dependency "net-ssh-gateway", ">= 1.0.1"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec",   "~> 1.3.0"


### PR DESCRIPTION
This feature is for those who don't know how to operate `ssh` or run Windows and don't know how to install `putty`, and want to target an instance using `vcap.me`

Usage:

```
vmc tunnel 10.21.165.60
Tunnel password: ******
can't bind to port 80
either add --tunnel-port to pick another port, or run with privileges
sudo vmc tunnel 10.21.165.60
```

It defaults to ssh user `vcap` and port `80` which all can be set with command line options.

```
vmc --tunnel-port --tunnel-password vmware tunnel 10.21.165.60
tunnel to 10.21.165.60 open for http://*.vcap.me:65535
Control-C to exit...
^C
closing tunnel...
```

It can also be used inline, if you want to use it in scripts:

```
vmc --tunnel-host 10.21.165.60 push --path ~/apps/foo -n foo
Creating Application: OK
Uploading Application:
  Checking for available resources: OK
  Packing application: OK
  Uploading (0K): OK   
Push Status: OK
Staging Application: OK                                                         
Starting Application: OK
```

It passes the vcap spec tests, but I've not run the bvt tests.
