### PR TITLE
Properly handle $no_proxy/localhost in a user's environment.

### DIFF
--- a/lib/vmc/client.rb
+++ b/lib/vmc/client.rb
@@ -11,6 +11,7 @@
 
 require 'rubygems'
 require 'json/pure'
+require 'open-uri'
 
 require File.expand_path('../const', __FILE__)
 
@@ -374,11 +375,7 @@ class VMC::Client
   end
 
   def perform_http_request(req)
-    if URI::HTTPS === URI.parse(req[:url])
-      RestClient.proxy = ENV['https_proxy'] || ENV['http_proxy']
-    else
-      RestClient.proxy = ENV['http_proxy']
-    end
+    RestClient.proxy = URI.parse(req[:url]).find_proxy()
 
     # Setup tracing if needed
     unless trace.nil?


### PR DESCRIPTION
When a user has $http(s)_proxy defined, vmc will often fail to target a local
VCAP environment. The cause of this was that vmc was looking directly to the
http_proxy or https_proxy environment variables without checking that the host
was not in $no_proxy, nor checking whether the target resolved to localhost.
Both of these checks are handled via the open-uri module's find_proxy() method.
