### PR TITLE
Accept parenthesized `require' syntax for detecting Sinatra.

### DIFF
--- a/lib/cli/frameworks.rb
+++ b/lib/cli/frameworks.rb
@@ -56,7 +56,7 @@ module VMC::Cli
               next if matched_file
               File.open(fname, 'r') do |f|
                 str = f.read # This might want to be limited
-                matched_file = fname if (str && str.match(/^\s*require\s*['"]sinatra['"]/))
+                matched_file = fname if (str && str.match(/^\s*require[\s\(]*['"]sinatra['"]/))
               end
             end
             if matched_file


### PR DESCRIPTION
This should fix detection for code that does `require("sinatra")` rather than `require "sinatra"`.
