### PR TITLE
Added a bash completion profile for the vmc command

### DIFF
--- a/etc/bash_completion.d/vmc
+++ b/etc/bash_completion.d/vmc
@@ -1,0 +1,14 @@
+# Author: Dustin Kirkland <kirkland@ubuntu.com>
+
+_vmc()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="$(vmc --help | grep "^    " | sed -e "s/^\s\+//" -e "s/ .*$//" | sort -u)"
+
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+}
+complete -F _vmc vmc


### PR DESCRIPTION
Playing with vmc this week, I found myself referring to the 'vmc help' menu as I was learning the various subcommands.

i found it quite useful to add this bash completion profile to my local /etc/bash_completion.d/vmc and then either log out, or source my ~/.bashrc.  Then, you can type "vmc <tab><tab>" and see a list of subcommands available.

We're carrying this in Ubuntu's vmc package, but I thought you might be interested in committing it upstream, too.

Signed-off-by: Dustin Kirkland kirkland@ubuntu.com
