### PR TITLE
Improve trace readability

### DIFF
--- a/lib/vmc/client.rb
+++ b/lib/vmc/client.rb
@@ -395,9 +395,17 @@ class VMC::Client
         puts '>>>'
         puts "PROXY: #{RestClient.proxy}" if RestClient.proxy
         puts "REQUEST: #{req[:method]} #{req[:url]}"
-        puts "RESPONSE_HEADERS: #{response.headers}"
+        puts "RESPONSE_HEADERS:"
+        response.headers.each do |key, value|
+            puts "    #{key} : #{value}"
+        end
         puts "REQUEST_BODY: #{req[:payload]}" if req[:payload]
-        puts "RESPONSE: [#{response.code}] #{response.body}"
+        puts "RESPONSE: [#{response.code}]"
+        begin
+            puts JSON.pretty_generate(JSON.parse(response.body))
+        rescue
+            puts "#{response.body}"
+        end
         puts '<<<'
       end
     end

--- a/lib/vmc/client.rb
+++ b/lib/vmc/client.rb
@@ -401,9 +401,13 @@ class VMC::Client
         end
         puts "REQUEST_BODY: #{req[:payload]}" if req[:payload]
         puts "RESPONSE: [#{response.code}]"
-        begin
-            puts JSON.pretty_generate(JSON.parse(response.body))
-        rescue
+        if response.headers[:content_type] && response.headers[:content_type].start_with?('application/json')
+            begin
+                puts JSON.pretty_generate(JSON.parse(response.body))
+            rescue
+                puts "#{response.body}"
+            end
+        else
             puts "#{response.body}"
         end
         puts '<<<'


### PR DESCRIPTION
vmc with -t option, response headers are printed with header names and values concatenated together due to hash#to_s and response body (typically json) is printed as a flowing string losing nesting, makes them quite unreadable

The proposed fix, pretty prints both, improving readability.

Best Regards,
-senthil
