### PR TITLE
Initial PHP support from PHP Fog

### DIFF
--- a/lib/cli/frameworks.rb
+++ b/lib/cli/frameworks.rb
@@ -14,6 +14,7 @@ module VMC::Cli
       'JavaWeb'  => ['spring',  { :mem => '512M', :description => 'Java Web Application'}],
       'Sinatra'  => ['sinatra', { :mem => '128M', :description => 'Sinatra Application'}],
       'Node'     => ['node',    { :mem => '64M',  :description => 'Node.js Application'}],
+      'PHP'      => ['php',     { :mem => '128M', :description => 'PHP Application'}],
       'Erlang/OTP Rebar' => ['otp_rebar',  { :mem => '64M',  :description => 'Erlang/OTP Rebar Application'}]
     }
 
@@ -73,6 +74,10 @@ module VMC::Cli
             if File.exist?('server.js') || File.exist?('app.js') || File.exist?('index.js') || File.exist?('main.js')
               return Framework.lookup('Node')
             end
+
+          # PHP
+          elsif !Dir.glob('*.php').empty?
+            return Framework.lookup('PHP')
 
           # Erlang/OTP using Rebar
           elsif !Dir.glob('releases/*/*.rel').empty? && !Dir.glob('releases/*/*.boot').empty?


### PR DESCRIPTION
Initial Cloud Foundry support for PHP using standard Apache + mod_php tools. The technology for these pull requests comes out of the knowledge and expertise of running phpfog.com

This request auto-detects php applications.

Related pull requests:

https://github.com/cloudfoundry/vcap-tests/pull/6

https://github.com/cloudfoundry/vcap/pull/105
