### PR TITLE
If target_file content does not end in whitespace, strip will return nil

### DIFF
--- a/lib/cli/config.rb
+++ b/lib/cli/config.rb
@@ -26,7 +26,7 @@ module VMC::Cli
         return @target_url if @target_url
         target_file = File.expand_path(TARGET_FILE)
         if File.exists? target_file
-          @target_url = lock_and_read(target_file).strip!
+          @target_url = lock_and_read(target_file).strip
           ha = @target_url.split('.')
           ha.shift
           @suggest_url = ha.join('.')


### PR DESCRIPTION
If target_file does not end in whitespace, strip will return nil to @target_url. VMC does create this file with whitespace at the end however this may not always happen if other applications modify this file. Other methods in the Config class that read files use ".strip".
