### PR TITLE
VMC::Cli::Config.lock_and_read does't work on particular ruby environment, such as JRuby.

### DIFF
--- a/lib/cli/config.rb
+++ b/lib/cli/config.rb
@@ -129,8 +129,12 @@ module VMC::Cli
       end
 
       def lock_and_read(file)
-        File.open(file, "r") {|f|
-          f.flock(File::LOCK_EX)
+        File.open(file, File::RDONLY) {|f|
+          if defined? JRUBY_VERSION
+            f.flock(File::LOCK_SH)
+          else
+            f.flock(File::LOCK_EX)
+          end
           contents = f.read
           f.flock(File::LOCK_UN)
           contents

--- a/lib/cli/config.rb
+++ b/lib/cli/config.rb
@@ -130,11 +130,7 @@ module VMC::Cli
 
       def lock_and_read(file)
         File.open(file, File::RDONLY) {|f|
-          if defined? JRUBY_VERSION
-            f.flock(File::LOCK_SH)
-          else
-            f.flock(File::LOCK_EX)
-          end
+          f.flock(File::LOCK_SH)
           contents = f.read
           f.flock(File::LOCK_UN)
           contents


### PR DESCRIPTION
JRuby(JDK) disallow exclusive locks on files opened only for read.
