### PR TITLE
Replace rubyzip2 with rubyzip

### DIFF
--- a/vmc.gemspec
+++ b/vmc.gemspec
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE"]
 
   s.add_dependency "json_pure", "~> 1.5.1"
-  s.add_dependency "rubyzip2", "~> 2.0.1"
+  s.add_dependency "rubyzip", "~> 0.9.4"
   s.add_dependency "rest-client", ">= 1.6.1", "< 1.7.0"
   s.add_dependency "terminal-table", "~> 1.4.2"
   s.add_dependency "interact", "~> 0.3.0"


### PR DESCRIPTION
The rubyzip2 maintainer recommends switching back to rubyzip, as it is now properly maintained and works with ruby 1.9.2. I've only tested this change with ruby 1.9.2, so someone should test with a ruby 1.8.7 client. If no one's done that by tomorrow night, I'll take care of it.
