### PR TITLE
Fix for infinite loop on Windows.

### DIFF
--- a/lib/cli/commands/base.rb
+++ b/lib/cli/commands/base.rb
@@ -38,7 +38,7 @@ module VMC::Cli
           if File.exists?(File.join(where, MANIFEST))
             @manifest_file = File.join(where, MANIFEST)
             break
-          elsif where == "/"
+          elsif File.basename(where) == "/"
             @manifest_file = nil
             break
           else


### PR DESCRIPTION
Fixed infinite loop due to the root path on windows being C:/ instead of /. Using File.basename resolves this.

Thanks,
Luke
