### PR TITLE
Add support runtime option to vmc manifest command.

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -8,6 +8,7 @@ module VMC
   module Cli
     autoload :Config,         "#{ROOT}/cli/config"
     autoload :Framework,      "#{ROOT}/cli/frameworks"
+    autoload :Runtime,        "#{ROOT}/cli/runtimes"
     autoload :Runner,         "#{ROOT}/cli/runner"
     autoload :ZipUtil,        "#{ROOT}/cli/zip_util"
     autoload :ServicesHelper, "#{ROOT}/cli/services_helper"

--- a/lib/cli/commands/base.rb
+++ b/lib/cli/commands/base.rb
@@ -224,6 +224,27 @@ module VMC::Cli
         end
         @frameworks
       end
+
+      def frameworks_with_runtimes_info
+        return @frameworks_with_runtimes if @frameworks_with_runtimes
+        info = client_info
+        @frameworks_with_runtimes = {}
+        if info[:frameworks]
+          info[:frameworks].each_value do |f|
+            runtimes = {}
+            runtimes[:runtimes] = {}
+            next unless f[:runtimes]
+            f[:runtimes].each do |r|
+              runtime_name = r[:name]
+              runtimes[:default] = runtime_name if r[:default]
+              runtimes[:runtimes][runtime_name] = r
+            end
+            @frameworks_with_runtimes[f[:name]] = runtimes
+          end
+        end
+        @frameworks_with_runtimes
+      end
+
     end
   end
 end

--- a/lib/cli/manifest_helper.rb
+++ b/lib/cli/manifest_helper.rb
@@ -108,6 +108,8 @@ module VMC::Cli::ManifestHelper
         "framework",
         "info"
       )
+      runtime = select_runtime framework
+      set runtime.name, "runtime"
     end
 
     set ask(
@@ -172,6 +174,27 @@ module VMC::Cli::ManifestHelper
     end
 
     framework
+  end
+
+  def select_runtime(framework, prompt_ok = true)
+    framework_name = framework.name
+    VMC::Cli::Runtime.load_all_runtimes frameworks_with_runtimes_info
+    runtime = VMC::Cli::Runtime.default_runtime_for framework_name
+    return runtime if !VMC::Cli::Runtime.has_multi_runtime? framework_name
+    runtimes = VMC::Cli::Runtime.runtimes_for framework_name
+    if ask "Use #{runtime} as a default runtime, Would you like to use other runtime?", :default => false
+      runtime = VMC::Cli::Runtime.lookup(
+        ask(
+          "Select Runtime",
+          :indexed => true,
+          :default => runtime,
+          :choices => runtimes.keys
+        )
+      )
+      display "Selected #{runtime}"
+    end
+
+    runtime
   end
 
   def bind_services(services)

--- a/lib/cli/runtimes.rb
+++ b/lib/cli/runtimes.rb
@@ -1,0 +1,68 @@
+module VMC::Cli
+
+  class Runtime
+
+    class << self
+
+      def load_all_runtimes(frameworks_with_runtimes)
+        @runtimes = {}
+        @default_runtimes = {}
+        @framework_runtimes = {}
+        frameworks_with_runtimes.each_pair do |framework, runtimes_info|
+          default_rt_name = runtimes_info[:default]
+          default_rt_info = runtimes_info[:runtimes][default_rt_name]
+          @default_runtimes[framework] = VMC::Cli::Runtime.new(default_rt_name, default_rt_info)
+          runtimes = {}
+          runtimes_info[:runtimes].each_pair do |rt_name, rt_info|
+            rt = VMC::Cli::Runtime.new(rt_name, rt_info)
+            runtimes[rt.to_s] = rt
+          end
+          @framework_runtimes[framework] = runtimes
+          @runtimes.merge! runtimes
+        end
+      end
+
+      def known_runtimes
+        return nil unless @runtimes
+        @runtimes.keys
+      end
+
+      def lookup(runtime)
+        return nil unless @runtimes
+        @runtimes[runtime]
+      end
+
+      def has_multi_runtime?(framework)
+        runtimes = runtimes_for framework
+        return false unless runtimes
+        1 < runtimes.size
+      end
+
+      def default_runtime_for(framework)
+        return nil unless @default_runtimes
+        @default_runtimes[framework]
+      end
+
+      def runtimes_for(framework)
+        return nil unless @framework_runtimes
+        @framework_runtimes[framework]
+      end
+
+    end
+
+    attr_reader :name, :version, :description, :default
+
+    def initialize(runtime=nil, opts={})
+      @name = runtime || 'unknown'
+      @version = opts[:version] || '0.999'
+      @description = opts[:description] || 'Unknown Runtime Type'
+      @default = opts[:default] || false
+    end
+
+    def to_s
+      description
+    end
+
+  end
+
+end

--- a/lib/cli/runtimes.rb
+++ b/lib/cli/runtimes.rb
@@ -9,7 +9,7 @@ module VMC::Cli
         @default_runtimes = {}
         @framework_runtimes = {}
         frameworks_with_runtimes.each_pair do |framework, runtimes_info|
-          default_rt_name = runtimes_info[:default]
+          default_rt_name = runtimes_info[:default] || runtimes_info[:runtimes].keys.first
           default_rt_info = runtimes_info[:runtimes][default_rt_name]
           @default_runtimes[framework] = VMC::Cli::Runtime.new(default_rt_name, default_rt_info)
           runtimes = {}

--- a/spec/assets/frameworks_with_runtimes.yml
+++ b/spec/assets/frameworks_with_runtimes.yml
@@ -1,0 +1,28 @@
+---
+sinatra:
+  default: ruby18
+  runtimes:
+    ruby18:
+        version: "1.8.7" # FIXME change to 1.8.7-p334
+        description: "Ruby 1.8.7"
+        default: true
+    ruby19:
+        version: "1.9.2p180"
+        description: "Ruby 1.9.2"
+
+node:
+  default: node
+  runtimes:
+    node:
+        version: '0.4.12'
+        description: 'Node.js'
+        default: true
+
+java_web:
+  default: java
+  runtimes:
+    java:
+        description: "Java 6"
+        version: "1.6"
+        executable: "java"
+        default: true

--- a/spec/unit/runtimes_spec.rb
+++ b/spec/unit/runtimes_spec.rb
@@ -1,0 +1,103 @@
+  require 'spec_helper'
+
+describe 'VMC::Cli::Runtime' do
+
+  before(:all) do
+    VMC::Cli::Runtime.load_all_runtimes build_frameworks_with_runtimes_info
+  end
+
+  it "should lookup runtime for Java Web Application framework" do
+    runtime = VMC::Cli::Runtime.default_runtime_for "java_web"
+    runtime.name.should == "java"
+    runtime.version.should == "1.6"
+    runtime.description.should == "Java 6"
+    runtime.default.should be_true
+  end
+
+  it "should list known runtimes" do
+    runtimes = VMC::Cli::Runtime.known_runtimes
+    runtimes.map do |rt_name|
+       VMC::Cli::Runtime.lookup(rt_name).name
+    end.should include "node", "ruby18", "ruby19", "java"
+  end
+
+  describe "sinatra framework has multi runtimes" do
+
+    it 'should list multi runtimes' do
+      runtimes = VMC::Cli::Runtime.runtimes_for "sinatra"
+      runtimes.values.map {|r| r.name }.should include "ruby18", "ruby19"
+    end
+
+    it 'should list ruby18 as a default runtime' do
+      default_runtime = VMC::Cli::Runtime.default_runtime_for "sinatra"
+      default_runtime.name.should == "ruby18"
+    end
+
+    it 'has multi runtimes' do
+      has_multi_runtimes = VMC::Cli::Runtime.has_multi_runtime? "sinatra"
+      has_multi_runtimes.should be_true
+    end
+
+  end
+
+  describe "node framework has a runtime" do
+
+    it 'should list a runtime' do
+      runtimes = VMC::Cli::Runtime.runtimes_for "node"
+      runtimes.values.map {|r| r.name }.should include "node"
+    end
+
+    it 'should list node as a default runtime' do
+      default_runtime = VMC::Cli::Runtime.default_runtime_for "node"
+      default_runtime.name.should == "node"
+    end
+
+    it 'has a runtime' do
+      has_multi_runtimes = VMC::Cli::Runtime.has_multi_runtime? "node"
+      has_multi_runtimes.should be_false
+    end
+
+  end
+
+  describe "java_web framework has a runtime" do
+
+    it 'should list a runtime' do
+      runtimes = VMC::Cli::Runtime.runtimes_for "java_web"
+      runtimes.values.map {|r| r.name }.should include "java"
+    end
+
+    it 'should list node as a default runtime' do
+      default_runtime = VMC::Cli::Runtime.default_runtime_for "java_web"
+      default_runtime.name.should == "java"
+    end
+
+    it 'has a runtime' do
+      has_multi_runtimes = VMC::Cli::Runtime.has_multi_runtime? "node"
+      has_multi_runtimes.should be_false
+    end
+
+  end
+
+  def build_frameworks_with_runtimes_info
+    yml = YAML.load_file spec_asset('frameworks_with_runtimes.yml')
+    frameworks_with_runtimes = {}
+    yml.each_pair do |framework, runtimes_info|
+      # "default", "runtimes" -> :default, :runtimes
+      new_runtimes_info = {}
+      runtimes_info.each_pair do |rts_key, rts_value|
+        rts_value.each_pair do |rt_key, rt_value|
+          # "version", "default", "description" -> :version, :default, :runtimes
+          new_rt_value = {}
+          rt_value.each_pair do |rt_attr_key, rt_attr|
+            new_rt_value[rt_attr_key.to_sym] = rt_attr
+          end
+          rts_value[rt_key] = new_rt_value
+        end if rts_value.is_a?(Hash)
+        new_runtimes_info[rts_key.to_sym] = rts_value
+      end
+      frameworks_with_runtimes[framework] = new_runtimes_info
+    end
+    frameworks_with_runtimes
+  end
+
+end


### PR DESCRIPTION
Hi.

Current vmc　manifest command is not working runtime option.
This pull request add runtmie option feature to vmc manifest command.

```
>vmc manifest
Configure for which application? [.]:
Application Name: env
Application Deployed URL [env.vcap.me]:
Detected a Sinatra Application, is this correct? [Yn]:
Use Ruby 1.8.7 as a default runtime, Would you like to use other runtime? [yN]: y
1: Ruby 1.8.7
2: Ruby 1.9.2
Select Runtime [Ruby 1.8.7]: 2
Selected Ruby 1.9.2
Memory reservation (128M, 256M, 512M, 1G, 2G) [128M]:
How many instances? [1]:
Would you like to bind any services to 'env'? [yN]:
Configure for another application? [yN]:
Manifest written to manifest.yml.

>type manifest.yml

---
applications:
  .:
    name: env
    url: ${name}.${target-base}
    framework:
      name: sinatra
      info:
        mem: 128M
        description: Sinatra Application
        exec: ruby app.rb
    runtime: ruby19
    mem: 128M
    instances: 1
```

This pull request depends on following small improvement for staging plugin.
https://github.com/cloudfoundry/vcap/pull/169

Thanks.
