### PR TITLE
Use rbconfig's RbConfig::CONFIG['host_os'] instead of RUBY_PLATFORM

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,6 +1,7 @@
-ROOT = File.expand_path(File.dirname(__FILE__))
-WINDOWS = !!(RUBY_PLATFORM =~ /mingw|mswin32|cygwin/)
+require "rbconfig"
 
+ROOT = File.expand_path(File.dirname(__FILE__))
+WINDOWS = !!(RbConfig::CONFIG['host_os'] =~ /mingw|mswin32|cygwin/)
 
 module VMC
   autoload :Client,           "#{ROOT}/vmc/client"

--- a/lib/cli/zip_util.rb
+++ b/lib/cli/zip_util.rb
@@ -10,7 +10,7 @@ module VMC::Cli
     class << self
 
       def to_dev_null
-        if !!RUBY_PLATFORM['mingw'] || !!RUBY_PLATFORM['mswin32'] || !!RUBY_PLATFORM['cygwin']
+        if !!WINDOWS
           'nul'
         else
           '/dev/null'


### PR DESCRIPTION
Hi.

This pull request is small improvement for vmc on jruby on windows.

Currently, vmc on jruby on windows often display ugly output, such as:

```
>vmc stop -n
Stopping Application 'app01': [0m[32mOK[0m
```

Because, vmc and gem 'interact' that vmc depends on, use RUBY_PLATFORM constants for detect host os.
but, RUBY_PLATFORM returns incorrect result in some situations. such as using on JRuby.

Ruby 1.9.3 on windows 7(64bit) result:

```
>ruby --version
ruby 1.9.3p0 (2011-10-30) [i386-mingw32]

>ruby -e "puts RUBY_PLATFORM"
i386-mingw32
```

JRuby 1.6.5.1 (Ruby 1.9 mode) on windows 7(64bit) result:

```
>jruby --version
jruby 1.6.5.1 (ruby-1.9.2-p136) (2011-12-27 1bf37c2) (Java HotSpot(TM) 64-Bit Server VM 1.7.0_02) [Windows 7-amd64-java]

>jruby -e "puts RUBY_PLATFORM"
java
```

The better way to detect host os is to use RbConfig::CONFIG['host_os'] instead of RUBY_PLATFORM constants.

Ruby 1.9.3 on windows 7(64bit) result:

```
>ruby -rrbconfig -e "puts RbConfig::CONFIG['host_os']"
mingw32
```

JRuby 1.6.5.1 (Ruby 1.9 mode) on windows 7(64bit) result:

```
>jruby -rrbconfig -e "puts RbConfig::CONFIG['host_os']"
mswin32
```

The above improvements, vmc will be fixed two problems on jruby on windows.
- vmc display ugly output
- VMC::Cli::ZipUtil.to_dev_null return null device correctly.

Thanks.
Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
