### PR TITLE
'vmc target' checks the /info on the old target not the new one

### DIFF
--- a/lib/vmc/cli.rb
+++ b/lib/vmc/cli.rb
@@ -389,7 +389,7 @@ module VMC
     end
 
     def client(target = client_target)
-      return @@client if defined?(@@client) && @@client
+      return @@client if defined?(@@client) && @@client && target==client_target
       return unless target
 
       info = target_info(target)


### PR DESCRIPTION
```
$ vmc target api.vcap.me
$ vmc info
... shutdown vcap.me
$ vmc target api.cloudfoundry.com
CFoundry::TargetRefused: target refused connection (Connection refused - connect(2))
For more information, see ~/.vmc/crash
```

If you switch on --trace you can see that vmc sends a GET to /info on the _old_ target as the first step in changing the target.  Looks like a bug (and a newish one - it worked fine with 0.4.7).

I'm using 0.5.0.rc1.
