### PR TITLE
Set VMC::CONFIG_DIR via ENV

### DIFF
--- a/lib/vmc/constants.rb
+++ b/lib/vmc/constants.rb
@@ -2,7 +2,7 @@ module VMC
   OLD_TARGET_FILE = "~/.vmc_target".freeze
   OLD_TOKENS_FILE = "~/.vmc_token".freeze
 
-  CONFIG_DIR = "~/.vmc".freeze
+  CONFIG_DIR = (ENV['VMC_CONFIG_DIR'].nil?) ? "~/.vmc" : ENV['VMC_CONFIG_DIR']
 
   LOGS_DIR = "#{CONFIG_DIR}/logs".freeze
   PLUGINS_FILE = "#{CONFIG_DIR}/plugins.yml".freeze


### PR DESCRIPTION
Enables VMC::CONFIG_DIR location to be set via an environment variable.
