### PR TITLE
Add HTTP proxy support

### DIFF
--- a/lib/vmc/cli.rb
+++ b/lib/vmc/cli.rb
@@ -29,6 +29,9 @@ module VMC
     option :proxy, :desc => "Run this command as another user (admin)", :alias => "-u",
       :value => :email
 
+    option :http_proxy, :desc => "Connect though an http proxy server", :alias => "--http-proxy",
+      :value => :http_proxy
+
     option :version, :desc => "Print version number", :alias => "-v",
       :default => false
 
@@ -409,6 +412,7 @@ module VMC
         end
 
       @@client.proxy = input[:proxy]
+      @@client.http_proxy = input[:http_proxy] || ENV['HTTP_PROXY'] || ENV['http_proxy'] || nil
       @@client.trace = input[:trace]
 
       uri = URI.parse(target)

--- a/spec/vmc/cli_spec.rb
+++ b/spec/vmc/cli_spec.rb
@@ -431,6 +431,37 @@ describe VMC::CLI do
           expect(context.client.proxy).to eq('foo@example.com')
         end
       end
+
+      context "when ENV['http_proxy'] is set" do
+        before { ENV['http_proxy'] = "http://lower.example.com:80" }
+        after { ENV.delete('http_proxy') }
+
+        it "uses the http proxy URI on the enviroenment" do
+          expect(context.client.http_proxy).to eq('http://lower.example.com:80')
+        end
+      end
+
+      context "when ENV['HTTP_PROXY'] is set" do
+        before { ENV['HTTP_PROXY'] = "http://upper.example.com:80" }
+        after { ENV.delete('HTTP_PROXY') }
+
+        it "uses the http proxy URI on the environement" do
+          expect(context.client.http_proxy).to eq('http://upper.example.com:80')
+        end
+      end
+
+      context "with a http proxy URI" do
+        before do
+          ENV['HTTP_PROXY'] = "http://should.be.overwritten.example.com:80"
+          stub(context).input { {:http_proxy => 'http://arg.example.com:80'} }
+        end
+        after { ENV.delete('HTTP_PROXY') }
+
+        it "uses the provided http proxy URI" do
+          expect(context.client.http_proxy).to eq('http://arg.example.com:80')
+        end
+      end
+
     end
 
     context "with a v2 cloud controller" do


### PR DESCRIPTION
I'd like to introduce HTTP proxy support to the current VMC.

This commit depends on the pull request below:
- https://github.com/cloudfoundry/vmc-lib/pull/11
