### PR TITLE
Add https proxy support

### DIFF
--- a/lib/vmc/cli.rb
+++ b/lib/vmc/cli.rb
@@ -32,6 +32,9 @@ module VMC
     option :http_proxy, :desc => "Connect though an http proxy server", :alias => "--http-proxy",
       :value => :http_proxy
 
+    option :https_proxy, :desc => "Connect though an https proxy server", :alias => "--https-proxy",
+      :value => :https_proxy
+
     option :version, :desc => "Print version number", :alias => "-v",
       :default => false
 
@@ -413,6 +416,7 @@ module VMC
 
       @@client.proxy = input[:proxy]
       @@client.http_proxy = input[:http_proxy] || ENV['HTTP_PROXY'] || ENV['http_proxy'] || nil
+      @@client.https_proxy = input[:https_proxy] || ENV['HTTPS_PROXY'] || ENV['https_proxy'] || nil
       @@client.trace = input[:trace]
 
       uri = URI.parse(target)


### PR DESCRIPTION
Adding https support to vmc command.
#66 added only the support for http_proxy and https support is missing.

vmc-lib already has https support by https://github.com/cloudfoundry/vmc-lib/pull/11 .

I wonder whether supporting `--http_proxy` and `--https_proxy` arguments by 'vmc' command is necessary or not. Supporting HTTP_PROXY and HTTPS_PROXY environment variables may be enough to set proxy servers.

BTW, do you have a plan to cherry-pack my pull requests on cf and cfoundry repository? I can send other pull requests to the repositories if needed.
