### PR TITLE
no interactive login with --force flag

### DIFF
--- a/lib/vmc/cli.rb
+++ b/lib/vmc/cli.rb
@@ -118,12 +118,16 @@ module VMC
       if !$vmc_asked_auth
         $vmc_asked_auth = true
 
-        line
-        line c("Not authenticated! Try logging in:", :warning)
+        hint = force? ? " with 'vmc login':" : ":"
 
-        # TODO: there's no color here; global flags not being passed
-        # through (mothership bug?)
-        invoke :login
+        line
+        line c("Not authenticated! Try logging in#{hint}", :warning)
+
+        if !force?
+          # TODO: there's no color here; global flags not being passed
+          # through (mothership bug?)
+          invoke :login
+        end
 
         retry
       end

--- a/spec/vmc/cli_spec.rb
+++ b/spec/vmc/cli_spec.rb
@@ -98,6 +98,27 @@ describe VMC::CLI do
       end
     end
 
+    context "with a CFoundry authentication error when the force flag is set" do
+      let(:action) { proc { raise CFoundry::InvalidAuthToken.new("foo bar") } }
+      let(:asked) { false }
+      let(:inputs) { { :force => true } }
+
+      before do
+        $vmc_asked_auth = asked
+      end
+
+      it "tells the user they are not authenticated" do
+        stub(context).invoke(:login)
+        subject
+        expect(stdout.string).to include "Not authenticated! Try logging in with 'vmc login':"
+      end
+
+      it "does not ask them to log in" do
+        dont_allow(context).invoke(:login)
+        subject
+      end
+    end
+
     context "with an arbitrary exception" do
       let(:action) { proc { raise "foo bar" } }
 


### PR DESCRIPTION
I am using vmc through a shell script.
I noticed that despite using the --force flag there would still be an interactive prompt to login the user. That seems to go against the documentation. Also it is not consistent with cli.rb's method `check_logged_in`

Use case:

```
 vmc logout
 vmc --force apps
```

should not do an interactive login.
